### PR TITLE
Lights: Correct values

### DIFF
--- a/exynos4/exynos4x12/liblights/lights.c
+++ b/exynos4/exynos4x12/liblights/lights.c
@@ -177,8 +177,8 @@ set_light_buttons(struct light_device_t* dev,
     int brightness = rgb_to_brightness(state);
 
     pthread_mutex_lock(&g_lock);
-    ALOGD("set_light_buttons: %d\n", brightness > 0 ? 1 : 2);
-    err = write_int(BUTTON_FILE, brightness > 0 ? 1 : 2);
+    ALOGD("set_light_buttons: %d\n", brightness > 0 ? 1 : 0);
+    err = write_int(BUTTON_FILE, brightness > 0 ? 1 : 0);
     pthread_mutex_unlock(&g_lock);
 
     return err;


### PR DESCRIPTION
Currently "2" value is used for OFF and "1" for ON. In samsung sources, "0" is used for OFF and "1" for ON. Correct this.

Requires also proper handling in kernel.
